### PR TITLE
Exception handling and PEP styleguide.

### DIFF
--- a/bin/decode.py
+++ b/bin/decode.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
 
-import sys,os,glob,copy
-import optparse
-import logging,traceback
-import gzip,zipfile,tempfile
-import output,util
-import dshell
-try: import pcap
-except:
+try:
+    import sys,os,glob,copy
+    import optparse
+    import logging,traceback
+    import gzip,zipfile,tempfile
+    import output,util
+    import dshell
+except ImportError as err:
+    print("Error, could not find library %s", err)
+
+try: 
+    import pcap
+
+except ImportError as err:
     pcap=None
-    print 'pcap not available: decoders requiring pcap are not usable'
+    print('pcap not available: decoders requiring pcap are not usable \n%s', err) 
 
 def import_module(name=None,silent=False,search={}):
     try:
@@ -32,7 +38,7 @@ def import_module(name=None,silent=False,search={}):
         elif name in dir(obj):
             obj = getattr(obj, name)
             if 'dObj' in dir(obj) or 'obj' in dir(obj): return obj
-    except Exception, err:
+    except Exception as err:
         if not silent: sys.stderr.write( "Error '%s' loading module %s\n" % (str(err),module))
     return False
 

--- a/bin/generate-dshellrc.py
+++ b/bin/generate-dshellrc.py
@@ -23,7 +23,7 @@ if __name__=='__main__':
     try:
         os.mkdir(os.path.join(cwd,'lib','python'+'.'.join(sys.version.split('.',3)[:2]).split(' ')[0]))
         os.mkdir(os.path.join(cwd,'lib','python'+'.'.join(sys.version.split('.',3)[:2]).split(' ')[0],'site-packages'))
-    except Exception,e:
+    except Exception as e:
         print(e)
 
 

--- a/bin/generate-dshellrc.py
+++ b/bin/generate-dshellrc.py
@@ -1,6 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
-import os, sys
+import os
+import sys
 
 if __name__=='__main__':
     cwd = sys.argv[1]
@@ -22,7 +23,9 @@ if __name__=='__main__':
     try:
         os.mkdir(os.path.join(cwd,'lib','python'+'.'.join(sys.version.split('.',3)[:2]).split(' ')[0]))
         os.mkdir(os.path.join(cwd,'lib','python'+'.'.join(sys.version.split('.',3)[:2]).split(' ')[0],'site-packages'))
-    except Exception,e: print e
+    except Exception,e:
+        print(e)
+
 
     envdict={}
     envdict.update(envvars)

--- a/bin/pcapanon.py
+++ b/bin/pcapanon.py
@@ -5,11 +5,14 @@ Created on Feb 6, 2012
 @author: tparker
 '''
 
-import sys,dpkt,struct,pcap,socket,time
-from Crypto.Random import random
-from Crypto.Hash import SHA
-from output import PCAPWriter
-from util import getopts
+try:
+    import sys,dpkt,struct,pcap,socket,time
+    from Crypto.Random import random
+    from Crypto.Hash import SHA
+    from output import PCAPWriter
+    from util import getopts
+except ImportError as err:
+    print("Error, missing package: %s", err)
 
 def hashaddr(addr,*extra):
     #hash key+address plus any extra data (ports if flow)

--- a/bin/pcapanon.py
+++ b/bin/pcapanon.py
@@ -100,7 +100,8 @@ def pcap_handler(ts,pktdata):
             except: sport=dport=None #nope
             pkt.data.src,pkt.data.dst=mangleIPs(pkt.data.src,pkt.data.dst,sport,dport)
         pktdata=str(pkt)
-    except Exception,e: print e
+    except Exception as error: 
+        print (error)
     out.write(len(pktdata),pktdata,ts)
 
 if __name__ == '__main__':

--- a/decoders/dns/dns-asn.py
+++ b/decoders/dns/dns-asn.py
@@ -1,5 +1,11 @@
-import dshell,dpkt,socket
-from dnsdecoder import DNSDecoder
+
+try:
+    import dshell
+    import dpkt
+    import socket
+    from dnsdecoder import DNSDecoder
+except ImportError as error:
+    print("Import error. Could not find module: %s", error)
 
 class DshellDecoder(DNSDecoder):
     def __init__(self):

--- a/decoders/http/httpdump.py
+++ b/decoders/http/httpdump.py
@@ -1,8 +1,13 @@
-import dshell
-import util
-import hashlib, urllib, re
+#!/usr/bin/env python
 
-from httpdecoder import HTTPDecoder
+try:
+    import dshell
+    import util
+    import hashlib, urllib, re
+
+    from httpdecoder import HTTPDecoder
+except ImportError as err:
+    print("Error, missing the following libraries: %s", err)
 
 class DshellDecoder(HTTPDecoder):
     def __init__(self):
@@ -23,7 +28,7 @@ class DshellDecoder(HTTPDecoder):
         self.output='colorout'
         self.gunzip=False   # Disable auto-gunzip as we want to indicate content that was compressed in the output
 
-    def HTTPHandler(self,conn,request,response,requesttime,responsetime):
+    def HTTPHandler(self,conn,request,response,requesttime,responsetime): # This is also in web.py, should this be just be imported from there??
         host = ''
         loc = ''
         uri = ''

--- a/decoders/http/rip-http.py
+++ b/decoders/http/rip-http.py
@@ -1,12 +1,22 @@
-import dshell,re
-import datetime, sys, string
+#!/usr/bin/env python
+
+try:
+    import dshell
+    import re
+    import datetime
+    import sys
+    import string
 
 #import any other modules here
 # import binascii
-import re, os, hashlib, util
+    import os
+    import hashlib
+    import util
 
 #we extend this
-from httpdecoder import HTTPDecoder
+    from httpdecoder import HTTPDecoder
+except ImportError as err:
+    print("Error, could not import: %s", err)
 
 class DshellDecoder(HTTPDecoder):
     def __init__(self):

--- a/decoders/http/web.py
+++ b/decoders/http/web.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-import dshell, dfile
+import dshell
+import dfile
 import util
 import hashlib
 

--- a/decoders/http/web.py
+++ b/decoders/http/web.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import dshell, dfile
 import util
 import hashlib
@@ -9,7 +10,7 @@ class DshellDecoder(HTTPDecoder):
         HTTPDecoder.__init__(self,
                 name='web',
                 description='Improved version of web that tracks server response',
-                filter='tcp and (port 80 or port 8080 or port 8000)',
+                filter='TCP and (port 80 or port 8080 or port 8000)',
                 filterfn=lambda ((sip,sp),(dip,dp)): sp in (80, 8000, 8080) or dp in (80, 8000, 8080),
                 author='bg,twp',
                 optiondict={
@@ -20,6 +21,8 @@ class DshellDecoder(HTTPDecoder):
         self.gunzip = False  # Not interested in response body
 
     def HTTPHandler(self,conn,request,response,requesttime,responsetime):
+        ''' Method to handle HTTP requests/responses. '''
+
         host = ''
         loc = ''
         lastmodified = ''
@@ -85,8 +88,9 @@ class DshellDecoder(HTTPDecoder):
             if response: self.write(response.body,direction='sc')
 
 
-    # MD5sum(hex) of the body portion of the response
     def _bodyMD5(self, response):
+    ''' MD5sum(hex) of the body portion of the response'''
+
         try:
             if len(response.body) > 0:
                 return hashlib.md5(response.body.rstrip('\0')).hexdigest()
@@ -96,6 +100,7 @@ class DshellDecoder(HTTPDecoder):
             return ''
 
     def POSTHandler(self,postdata):
+        ''' HTTP method to handle POST requests '''
         next_line_is_data=False
         contenttype = ''
         filename = ''
@@ -118,6 +123,7 @@ class DshellDecoder(HTTPDecoder):
         return contenttype,filename,l
 
     def splitstrip(self,data,sep,strip=' '):
+        ''' Formatting data '''
         return [lpart.strip(strip) for lpart in data.split(sep)]
 
 


### PR DESCRIPTION
In an effort to add better exception handling if modules do not exist I modified a few files (as shown below) to gracefully close if an module does not exist and inform the user of the error. Additionally, adding parenthesis around print statements was done to try to make this compatible with Python 2.7 and Python 3 (it doesn't look like there's any reason this can't be used with either interpreter after additional modifications).  Having one import per line is the "Pythonic" and [PEP style guide recommended way](https://www.python.org/dev/peps/pep-0008/#imports).  Doc Strings should be added to each Classes' methods to remove ambiguity of their functionality (I've corrected a couple, and will do more when I have time).
