### PR TITLE
fixed python invocation

### DIFF
--- a/bin/decode.py
+++ b/bin/decode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 # pylint: disable-msg=C0103,E501
 

--- a/bin/generate-dshellrc.py
+++ b/bin/generate-dshellrc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2.7
 
 import os
 import sys

--- a/bin/pcapanon.py
+++ b/bin/pcapanon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 '''
 Created on Feb 6, 2012
 

--- a/decoders/templates/PacketDecoder.py
+++ b/decoders/templates/PacketDecoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import dshell
 import output

--- a/decoders/templates/SessionDecoder.py
+++ b/decoders/templates/SessionDecoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import dshell
 import output

--- a/install-ubuntu.py
+++ b/install-ubuntu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 from pkgutil import iter_modules
 from subprocess import call

--- a/lib/dnsdecoder.py
+++ b/lib/dnsdecoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import dshell
 import util

--- a/lib/httpdecoder.py
+++ b/lib/httpdecoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 import dshell
 import util
 import dpkt


### PR DESCRIPTION
Some linux distros have python 3.4 by default, this PR makes Dshell explicitly call the exact version of python needed
