### PR TITLE
support DOS/Unix line endings in decode_base64()

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -43,7 +43,8 @@ def decode_base64(intext, alphabet='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 
     outtext = ''
 
-    intext = intext.rstrip('\n')
+    # support DOS and Unix line endings
+    intext = intext.rstrip('\r\n')
 
     i = 0
     while i < len(intext) - 3:


### PR DESCRIPTION
Support both DOS/Windows and Unix line endings in the base64 decoder.