### PR TITLE
DNSDecoder class now uses packetHandler to process UDP in realtime

### DIFF
--- a/lib/dnsdecoder.py
+++ b/lib/dnsdecoder.py
@@ -29,35 +29,60 @@ class DNSDecoder(dshell.TCPDecoder):
         self.requests = {}
         self.maxblobs = None
 
+    def packetHandler(self,udp,data):
+	'''for each UDP packet , examine each segment (UDP packet) seperately as each will be a DNS Q/A
+                pair Q/A by ID and return as pairs'''
+	addr=udp.addr
+	if addr[0][1] < addr[1][1]: addr=addr[1],addr[0] #swap ports if source port is lower, to keep tuple (client,server)
+	connrqs = self.requests.setdefault(addr, {})
+	try:
+		dns = dpkt.dns.DNS(data)
+	except Exception, e:
+		self._exc(e)
+	if dns.qr == dpkt.dns.DNS_Q: 
+		connrqs[dns.id] = [udp.ts, dns, 0]
+	elif dns.qr == dpkt.dns.DNS_A:
+                rq = connrqs.get(dns.id, [None, None, 0])
+                rq[2] += 1
+                if "DNSHandler" in dir(self):
+                    self.DNSHandler(conn=udp, request=rq[1], response=dns, requesttime=rq[0],
+                                    responsetime=udp.ts, responsecount=rq[2])
+	
     def blobHandler(self, conn, blob):
         '''for each blob, examine each segment (UDP packet) seperately as each will be a DNS Q/A
                 pair Q/A by ID and return as pairs'''
         connrqs = self.requests.setdefault(conn, {})
-        # iterate blob as each packet will be a seperate request (catches
-        # spoofing)
+        # iterate blob as each packet will be a seperate request (catches spoofing)
         for data in blob:
             try:
                 dns = dpkt.dns.DNS(data)
             except Exception, e:
                 self._exc(e)
+                continue
             if dns.qr == dpkt.dns.DNS_Q:
                 connrqs[dns.id] = [blob.starttime, dns, 0]
             elif dns.qr == dpkt.dns.DNS_A:
                 rq = connrqs.get(dns.id, [None, None, 0])
                 rq[2] += 1
                 if "DNSHandler" in dir(self):
-                    self.DNSHandler(conn=conn, request=rq[1], response=dns, requesttime=rq[
-                                    0], responsetime=blob.starttime, responsecount=rq[2])
+                    self.DNSHandler(conn=conn, request=rq[1], response=dns, requesttime=rq[0],
+                                    responsetime=blob.starttime, responsecount=rq[2])
 
-    def connectionHandler(self, conn):
+    def connectionHandler(self,conn):
         '''clean up unanswered requests when we discard the connection'''
-        if self.noanswer and "DNSHandler" in dir(self) and self.requests.get(conn):
-            for requesttime, request, responsecount in self.requests[conn].values():
-                if not responsecount:
-                    self.DNSHandler(conn=conn, request=request, response=None,
-                                    requesttime=requesttime, responsetime=None, responsecount=responsecount)
-        if conn in self.requests:
-            del self.requests[conn]
+	if self.noanswer and "DNSHandler" in dir(self) and self.requests.get(conn):
+		for requesttime, request, responsecount in self.requests[conn].values():
+			if not responsecount:
+				if type(conn) is tuple: conn=dshell.Packet(self,conn) #wrap UDP addresses
+				self.DNSHandler(conn=conn, request=request, response=None,
+						requesttime=requesttime, responsetime=None, responsecount=responsecount)
+	if conn in self.requests:
+		del self.requests[conn]
+
+    def postModule(self):
+	'''flush out all remaining request state when module exits'''
+	for conn in self.requests.keys():
+		self.connectionHandler(conn)
 
 
 class displaystub(dshell.Decoder):
@@ -72,5 +97,5 @@ class displaystub(dshell.Decoder):
 if __name__ == '__main__':
     dObj = displaystub()
     print dObj
-else:
+else:  # do we always want to print something here? Maybe only in debug mode?:
     dObj = displaystub()


### PR DESCRIPTION
DNSDecoder will now produce real-time output for UDP query/response pairs by using packetHandler to process UDP packets immediately. UDP state is tracked like connections, with a (client_addr,server_addr) tuple and DNS IDs being used to track queries and responses. 

DNSHandler is called at response time with a Packet object (parent class of Connection) based on the current UDP packet. All other args passed to DNSHandler remain the same. A postModule method is used to flush outstanding UDP state at shutdown. 

Tested as compatible with decoders/dns/dns.py on sample traffic.