### PR TITLE
Reverse HTTP Support

### DIFF
--- a/lib/httpdecoder.py
+++ b/lib/httpdecoder.py
@@ -36,13 +36,13 @@ class HTTPDecoder(dshell.TCPDecoder):
 
     def blobHandler(self, conn, blob):
         '''buffer the request blob and call the handler once we have the response blob'''
-        if blob.direction == 'cs':
+        if conn not in self.requests:
             try:
                 self.requests[conn] = (
                     blob.starttime, dpkt.http.Request(blob.data(self.errorH)))
             except Exception, e:
                 self.UnpackError(e)
-        elif blob.direction == 'sc' and conn in self.requests:
+        else:
             try:
                 if 'HTTPHandler' in dir(self):
                     response = dpkt.http.Response(blob.data(self.errorH))


### PR DESCRIPTION
Updated httpdecoder to be less picky about directionality of HTTP REQUEST on the C->S and RESPONSE on the converse.  I've seen anomalies where the opposite occurs, sometimes due to packet loss, but also intentionally by way of proxy or tcp relay.

Here is some sample traffic that I crafted of a reverse GET request to Google:
   https://www.dropbox.com/s/hprypg075r4rddl/reverse_http.pcap

I'll keep the dropbox link active long enough to support any discussion around this pull request.  Unfortunately Github doesn't support pcap file attachments.