### PR TITLE
Create install-gentoo.py

### DIFF
--- a/install-gentoo.py
+++ b/install-gentoo.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from pkgutil import iter_modules
+from subprocess import call
+
+dependencies = {
+    "Crypto": "dev-python/pycrypto",
+    "dpkt": "dev-python/dpkt",
+    "IPy": "dev-python/ipy",
+    "pcap": "dev-python/pypcap",
+    "pygeoip" : "dev-python/pygeoip",
+    "pydoc":"dev-python/epydoc", 
+ }
+
+installed, missing_pkgs = [pkg[1] for pkg in iter_modules()], []
+
+for module, pkg in dependencies.items():
+    if module not in installed:
+        print("dshell requires {}".format(module))
+        missing_pkgs.append("python-{}".format(pkg))
+    else:
+        print("{} is installed".format(module))
+
+if missing_pkgs:
+    print("Hello, Calling Emerge to Build packages that are missing")
+    cmd = ["emerge --sync --quiet && emerge -v",] + missing_pkgs 
+    call(["make", "all"]) 
+#Notes to DSHELL TEAM. can TRIM this DOWN if you wish. this is hear as a conveniance/reffrance to you. 
+#  Emerge -av --ask --verbose else emerge foo --quiet to shut up build/emerge messages
+# emerge --sync --quiet and or emerge-webrsync --quiet gets all the updates for ebuild scripts/security/metadata/etc , updates to portage spam the console, 
+# --quiet or remove for the reasuring flurry of text , emerge -v (verbose) , emerge -av give promt to user.
+# USE="+DOC +KDE -GTK -VLC" emerge foo-basket? some?package to enable + , DISABLE use-flag -
+## Gentoo way is offer a choice make rc,init 
+# then offer docs via USE="+docks in ebuilds when calling python or disutils.eclass's 
+# I pruned the Do you want the docs asker below too much of a problem. 
+# for Sabayon (Gentoo overlay , Binary Distro of Gentoo) USers will need (more or less Strongly recomended) to Run equo i + missing_pkgs & or allow the emerge to post
+print("Emerge compleated, NOTE:if you are a Sabayon User (Gentoo-overlay/BIN-overlay) you will Likely whish to resync Portage to Entropy")
+print("equo rescue spmsync, to do this , else entropy; Your binary pkg-manager may not be aware that $missing_pkgs were installed")

--- a/install-gentoo.py
+++ b/install-gentoo.py
@@ -24,7 +24,11 @@ for module, pkg in dependencies.items():
 if missing_pkgs:
     print("Hello, Calling Emerge to Build packages that are missing")
     cmd = ["emerge --sync --quiet && emerge -v",] + missing_pkgs 
-    call(["make", "all"]) 
+
+    print(" ".join(cmd))
+    call(cmd)
+
+call(["make", "all"])
 #Notes to DSHELL TEAM. can TRIM this DOWN if you wish. this is hear as a conveniance/reffrance to you. 
 #  Emerge -av --ask --verbose else emerge foo --quiet to shut up build/emerge messages
 # emerge --sync --quiet and or emerge-webrsync --quiet gets all the updates for ebuild scripts/security/metadata/etc , updates to portage spam the console, 


### PR DESCRIPTION
logs in issue prove it works http://gpo.zugaina.org/dev-python/pygeoip is in overlay which is not  in the defacto tree. 
layman -a [gentoo-zh](http://gpo.zugaina.org/Overlays/gentoo-zh) or necromancy-overlay (of which i'm banging on a DSHELL Ebuild for it. thus I added the dependency to my'nown overlay.  
can be installed via pip install (however its strongly DISCOURAGED as it will likely destroy python overtime and or break core system depends and or can cause serious breakage.)

https://github.com/USArmyResearchLab/Dshell/issues/71 previously
 i forgot commas at the end of 2 packages. fixed that , 
you know what they say eat your own dog food. 
some of the errors is due to the copy of portage on the live DVD being 3-6 months stale. 

spike Dshell-master # ./install-gentoo.py
pygeoip is installed
Crypto is installed
dpkt is installed
pydoc is installed
IPy is installed
pcap is installed
make: getcwd: No such file or directory
make: Warning: File 'Makefile' has modification time 299608 s in the future
# Generating .dshellrc and dshell files

shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
python /home/spikeuser/Downloads/Dshell-master/bin/generate-dshellrc.py /home/spikeuser/Downloads/Dshell-master
[Errno 17] File exists: '/home/spikeuser/Downloads/Dshell-master/lib/python2.7'
chmod 755 /home/spikeuser/Downloads/Dshell-master/dshell
chmod 755 /home/spikeuser/Downloads/Dshell-master/dshell-decode
chmod 755 /home/spikeuser/Downloads/Dshell-master/bin/decode.py
ln -s /home/spikeuser/Downloads/Dshell-master/bin/decode.py /home/spikeuser/Downloads/Dshell-master/bin/decode
find /home/spikeuser/Downloads/Dshell-master/decoders -type d -not -path *.svn* -print -exec touch {}/**init**.py \;
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
/home/spikeuser/Downloads/Dshell-master/decoders
/home/spikeuser/Downloads/Dshell-master/decoders/tftp
/home/spikeuser/Downloads/Dshell-master/decoders/templates
/home/spikeuser/Downloads/Dshell-master/decoders/smb
/home/spikeuser/Downloads/Dshell-master/decoders/protocol
/home/spikeuser/Downloads/Dshell-master/decoders/misc
/home/spikeuser/Downloads/Dshell-master/decoders/http
/home/spikeuser/Downloads/Dshell-master/decoders/ftp
/home/spikeuser/Downloads/Dshell-master/decoders/flows
/home/spikeuser/Downloads/Dshell-master/decoders/filter
/home/spikeuser/Downloads/Dshell-master/decoders/dns
/home/spikeuser/Downloads/Dshell-master/decoders/dhcp
(cd /home/spikeuser/Downloads/Dshell-master/doc && ./generate-doc.sh /home/spikeuser/Downloads/Dshell-master ) 
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
chdir: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
wrote dfile.html
wrote dnsdecoder.html
wrote dshell.html
wrote httpdecoder.html
wrote smbdecoder.html
wrote util.html
wrote colorout.html
wrote csvout.html
wrote jsonout.html
wrote netflowout.html
wrote output.html
wrote xmlout.html
no Python documentation found for 'decode'
no Python documentation found for 'generate-dshellrc'
no Python documentation found for 'pcapanon'
wrote tftp.html
wrote SessionDecoder.html
wrote PacketDecoder.html
wrote smbfiles.html
wrote rip-smb-uploads.html
wrote psexec.html
wrote protocol.html
wrote ip.html
wrote ether.html
wrote xor.html
wrote writer.html
wrote synrst.html
wrote merge.html
wrote grep.html
wrote followstream.html
wrote web.html
wrote rip-http.html
wrote ms15-034.html
wrote httpdump.html
wrote flash-detect.html
wrote ftp.html
wrote reverse-flow.html
wrote netflow.html
wrote long-flows.html
wrote large-flows.html
wrote track.html
wrote snort.html
wrote country.html
wrote asn-filter.html
wrote reservedips.html
wrote innuendo-dns.html
wrote dns.html
wrote dns-cc.html
wrote dns-asn.html
wrote dhcp.html
make: warning:  Clock skew detected.  Your build may be incomplete.
Emerge compleated, NOTE:if you are a Sabayon User (Gentoo-overlay/BIN-overlay) you will Likely whish to resync Portage to Entropy
equo rescue spmsync, to do this , else entropy; Your binary pkg-manager may not be aware that $missing_pkgs were installed
spike Dshell-master # 

only notes for gentoo was sometimes i had to KILL DSHELL git clone .... 
*_MAKE CLEAN did nt get it all. *_

5TH TEST 
spike Dshell-master # ./install-gentoo.py
pygeoip is installed
Crypto is installed
dpkt is installed
pydoc is installed
IPy is installed
pcap is installed
make: Warning: File 'Makefile' has modification time 298675 s in the future
# Generating .dshellrc and dshell files

python /home/spikeuser/Downloads/Dshell-master/bin/generate-dshellrc.py /home/spikeuser/Downloads/Dshell-master
[Errno 17] File exists: '/home/spikeuser/Downloads/Dshell-master/lib/python2.7'
chmod 755 /home/spikeuser/Downloads/Dshell-master/dshell
chmod 755 /home/spikeuser/Downloads/Dshell-master/dshell-decode
chmod 755 /home/spikeuser/Downloads/Dshell-master/bin/decode.py
ln -s /home/spikeuser/Downloads/Dshell-master/bin/decode.py /home/spikeuser/Downloads/Dshell-master/bin/decode
find /home/spikeuser/Downloads/Dshell-master/decoders -type d -not -path *.svn* -print -exec touch {}/**init**.py \;
/home/spikeuser/Downloads/Dshell-master/decoders
/home/spikeuser/Downloads/Dshell-master/decoders/tftp
/home/spikeuser/Downloads/Dshell-master/decoders/templates
/home/spikeuser/Downloads/Dshell-master/decoders/smb
/home/spikeuser/Downloads/Dshell-master/decoders/protocol
/home/spikeuser/Downloads/Dshell-master/decoders/misc
/home/spikeuser/Downloads/Dshell-master/decoders/http
/home/spikeuser/Downloads/Dshell-master/decoders/ftp
/home/spikeuser/Downloads/Dshell-master/decoders/flows
/home/spikeuser/Downloads/Dshell-master/decoders/filter
/home/spikeuser/Downloads/Dshell-master/decoders/dns
/home/spikeuser/Downloads/Dshell-master/decoders/dhcp
(cd /home/spikeuser/Downloads/Dshell-master/doc && ./generate-doc.sh /home/spikeuser/Downloads/Dshell-master ) 
wrote dfile.html
wrote dnsdecoder.html
wrote dshell.html
wrote httpdecoder.html
wrote smbdecoder.html
wrote util.html
wrote colorout.html
wrote csvout.html
wrote jsonout.html
wrote netflowout.html
wrote output.html
wrote xmlout.html
no Python documentation found for 'decode'
no Python documentation found for 'generate-dshellrc'
no Python documentation found for 'pcapanon'
wrote tftp.html
wrote SessionDecoder.html
wrote PacketDecoder.html
wrote smbfiles.html
wrote rip-smb-uploads.html
wrote psexec.html
wrote protocol.html
wrote ip.html
wrote ether.html
wrote xor.html
wrote writer.html
wrote synrst.html
wrote merge.html
wrote grep.html
wrote followstream.html
wrote web.html
wrote rip-http.html
wrote ms15-034.html
wrote httpdump.html
wrote flash-detect.html
wrote ftp.html
wrote reverse-flow.html
wrote netflow.html
wrote long-flows.html
wrote large-flows.html
wrote track.html
wrote snort.html
wrote country.html
wrote asn-filter.html
wrote reservedips.html
wrote innuendo-dns.html
wrote dns.html
wrote dns-cc.html
wrote dns-asn.html
wrote dhcp.html
make: warning:  Clock skew detected.  Your build may be incomplete.
Emerge compleated, NOTE:if you are a Sabayon User (Gentoo-overlay/BIN-overlay) you will Likely whish to resync Portage to Entropy
equo rescue spmsync, to do this , else entropy; Your binary pkg-manager may not be aware that $missing_pkgs were installed
spike Dshell-master # ls
bin       doc     dshell         install-gentoo.py  lib          Makefile   share
decoders  docker  dshell-decode  install-ubuntu.py  LICENSE.txt  README.md
spike Dshell-master # dshell --help
bash: dshell: command not found
spike Dshell-master # ./dshell
root@spike:/home/spikeuser/Downloads/Dshell-master Dshell> help
GNU bash, version 4.3.33(1)-release (x86_64-pc-linux-gnu)
These shell commands are defined internally.  Type `help' to see this list.
Type`help name' to find out more about the function `name'.
Use`info bash' to find out more about the shell in general.
Use `man -k' or`info' to find out more about commands not in this list.

A star (*) next to a name means that the command is disabled.

 job_spec [&]                                           history [-c] [-d offset] [n] or history -anrw [file>
 (( expression ))                                       if COMMANDS; then COMMANDS; [ elif COMMANDS; then C>
 . filename [arguments]                                 jobs [-lnprs] [jobspec ...] or jobs -x command [arg>
 :                                                      kill [-s sigspec | -n signum | -sigspec] pid | jobs>
 [ arg... ]                                             let arg [arg ...]
 [[ expression ]]                                       local [option] name[=value] ...
 alias [-p] [name[=value] ... ]                         logout [n]
 bg [job_spec ...]                                      mapfile [-n count] [-O origin] [-s count] [-t] [-u >
 bind [-lpsvPSVX] [-m keymap] [-f filename] [-q name]>  popd [-n] [+N | -N]
 break [n]                                              printf [-v var] format [arguments]
 builtin [shell-builtin [arg ...]]                      pushd [-n] [+N | -N | dir]
 caller [expr]                                          pwd [-LP]
 case WORD in [PATTERN [| PATTERN]...) COMMANDS ;;]..>  read [-ers] [-a array] [-d delim] [-i text] [-n nch>
 cd [-L|[-P [-e]] [-@]] [dir]                           readarray [-n count] [-O origin] [-s count] [-t] [->
 command [-pVv] command [arg ...]                       readonly [-aAf] [name[=value] ...] or readonly -p
 compgen [-abcdefgjksuv] [-o option]  [-A action] [-G>  return [n]
 complete [-abcdefgjksuv] [-pr] [-DE] [-o option] [-A>  select NAME [in WORDS ... ;] do COMMANDS; done
 compopt [-o|+o option] [-DE] [name ...]                set [-abefhkmnptuvxBCHP] [-o option-name] [--] [arg>
 continue [n]                                           shift [n]
 coproc [NAME] command [redirections]                   shopt [-pqsu] [-o] [optname ...]
 declare [-aAfFgilnrtux] [-p] [name[=value] ...]        source filename [arguments]
 dirs [-clpv] [+N] [-N]                                 suspend [-f]
 disown [-h] [-ar] [jobspec ...]                        test [expr]
 echo [-neE] [arg ...]                                  time [-p] pipeline
 enable [-a] [-dnps] [-f filename] [name ...]           times
 eval [arg ...]                                         trap [-lp] [[arg] signal_spec ...]
 exec [-cl] [-a name] [command [arguments ...]] [redi>  true
 exit [n]                                               type [-afptP] name [name ...]
 export [-fn] [name[=value] ...] or export -p           typeset [-aAfFgilrtux] [-p] name[=value] ...
 false                                                  ulimit [-SHabcdefilmnpqrstuvxT] [limit]
 fc [-e ename] [-lnr] [first] [last] or fc -s [pat=re>  umask [-p] [-S] [mode]
 fg [job_spec]                                          unalias [-a] name [name ...]
 for NAME [in WORDS ... ] ; do COMMANDS; done           unset [-f] [-v] [-n] [name ...]
 for (( exp1; exp2; exp3 )); do COMMANDS; done          until COMMANDS; do COMMANDS; done
 function name { COMMANDS ; } or name () { COMMANDS ;>  variables - Names and meanings of some shell variab>
 getopts optstring name [arg]                           wait [-n] [id ...]
 hash [-lr] [-p pathname] [-dt] [name ...]              while COMMANDS; do COMMANDS; done
 help [-dms] [pattern ...]                              { COMMANDS ; }
root@spike:/home/spikeuser/Downloads/Dshell-master Dshell> exit

other Than copying to /opt/bin ,/usr/bin ,  it builds as agreed. 
