### PR TITLE
requestInfo format for web CONNECT

### DIFF
--- a/decoders/http/web.py
+++ b/decoders/http/web.py
@@ -81,7 +81,7 @@ class DshellDecoder(HTTPDecoder):
             uploadfile = None
 
         requestInfo = '%s %s%s HTTP/%s' % (request.method,
-                                           host,
+                                           host if host != request.uri else '',  # With CONNECT method, the URI is or contains the host, making this redudant
                                            request.uri[:self.maxurilen] + '[truncated]' if self.maxurilen > 0 and len(
                                                request.uri) > self.maxurilen else request.uri,
                                            request.version)


### PR DESCRIPTION
This is a minor change to the way the host field is displayed when hosts are repeated in the URI (such as with proxy CONNECT).  No change to the kwarg output to alert, just the display in requestInfo.