### PR TITLE
Init decoder's custom output module

### DIFF
--- a/bin/decode.py
+++ b/bin/decode.py
@@ -309,7 +309,7 @@ def initDecoderOptions(decoder, out, options, decoder_args, decoder_options):
         # global
         # provide global output module under alternate name
         decoder.globalout = out
-        # decoder.out.__init__(fh=out.fh) #re-init the decoder
+        decoder.out.__init__(fh=out.fh) #re-init the decoder
         try:
             # If the decoder's default output doesn't have a filehandle set,
             # use the user provided one


### PR DESCRIPTION
I restored a line that had previously been commented out to (re)initialize the decoder's custom output module.  Without this call, the initial call to `__init__` done at the decoder load time doesn't have access to the output filehandle, and therefore any writes done within the output initialization are vaporized.  Results are most obvious when a decoder uses __colorout__ and the output is directed to an HTML file using `-o`.

Example command: `decode -d followstream file.pcap -o streams.html`

Without this call to `__init__` in decode.py, the HTML headers including stylesheets are not written to the output file.