### PR TITLE
Added 'setup' function to output modules

### DIFF
--- a/bin/decode.py
+++ b/bin/decode.py
@@ -309,7 +309,6 @@ def initDecoderOptions(decoder, out, options, decoder_args, decoder_options):
         # global
         # provide global output module under alternate name
         decoder.globalout = out
-        # decoder.out.__init__(fh=out.fh) #re-init the decoder
         try:
             # If the decoder's default output doesn't have a filehandle set,
             # use the user provided one
@@ -324,6 +323,9 @@ def initDecoderOptions(decoder, out, options, decoder_args, decoder_options):
             decoder.out.pcapwriter = out.pcapwriter
     # set the logger
     decoder.out.logger = logging.getLogger(decoder.name)
+
+    # perform any output module setup before processing data
+    decoder.out.setup()
 
     # set output format string, or reset to default
     # do not override --oformat specified string

--- a/lib/output/colorout.py
+++ b/lib/output/colorout.py
@@ -110,11 +110,6 @@ class ColorOutput(output.TextOutput):
         # Call parent init
         output.TextOutput.__init__(self, format=fmtstr, **kwargs)
 
-        self.setColorMode()
-
-        # Write Header
-        if self._COLORMODE == 'HTML':
-            self._htmlwrite(self._HTMLHeader(self.title))
 
         # In HTML mode, if we get any single call
         # to write() with the time option set, we will set
@@ -122,6 +117,14 @@ class ColorOutput(output.TextOutput):
         # on initial page load.  Otherwise, timestamps will be hidden
         # until toggled by the user
         self._htmldisplaytimes = False
+
+    def setup(self):
+        # Write Header
+        self.setColorMode()
+
+        if self._COLORMODE == 'HTML':
+            self._htmlwrite(self._HTMLHeader(self.title))
+
 
     def setColorMode(self):
         # Determine output mode

--- a/lib/output/csvout.py
+++ b/lib/output/csvout.py
@@ -29,10 +29,10 @@ class CSVOutput(output.TextOutput):
         args will have the name of the module as args[0], anything else after
         '''
         # start with a set of default fields
-        fields = self._DEFAULT_FIELDS
+        self.fields = self._DEFAULT_FIELDS
 
         if 'format' in kwargs:
-            fields = []
+            self.fields = []
             fmtstr = kwargs['format']
             del kwargs['format']  # don't let base class process this
         else:
@@ -40,11 +40,13 @@ class CSVOutput(output.TextOutput):
 
         # set delimiter
         if 'delim' in kwargs:
-            delim = kwargs['delim']
-            if delim.lower() == 'tab':
-                delim = "\t"
+            self.delim = kwargs['delim']
+            if self.delim.lower() == 'tab':
+                self.delim = "\t"
         else:
-            delim = self._DEFAULT_DELIM
+            self.delim = self._DEFAULT_DELIM
+
+        self.noheader = 'noheader' in kwargs
 
         # parse args as fields
         if len(args):
@@ -53,19 +55,21 @@ class CSVOutput(output.TextOutput):
                     f, t = a.split(':')  # split on field:type
                 except:
                     f, t = a, 's'  # default to string type
-                fields.append((f, t))
+                self.fields.append((f, t))
 
         # build format string to pass to textoutput
         if fmtstr:
-            fmtstr += delim
-        fmtstr += delim.join(['%%(%s)%s' % (f, t) for f, t in fields])
+            fmtstr += self.delim
+        fmtstr += self.delim.join(['%%(%s)%s' % (f, t) for f, t in self.fields])
 
         # everything else is exactly like the text output module
         output.TextOutput.__init__(self, format=fmtstr, **kwargs)
 
+
+    def setup(self):
         # print header if not suppressed
-        if self.fh and 'noheader' not in kwargs:
-            self.fh.write('#' + delim.join([f[0] for f in fields]) + "\n")
+        if self.fh and not self.noheader:
+            self.fh.write('#' + self.delim.join([f[0] for f in self.fields]) + "\n")
 
 '''NOTE: output modules return obj=reference to the CLASS
     instead of a dObj=instance so we can init with args'''

--- a/lib/output/output.py
+++ b/lib/output/output.py
@@ -197,6 +197,14 @@ class Output(object):
         if m == 'dump':
             self.dump(*args, **kwargs)
 
+    def setup(self):
+        """
+        Perform any additional setup outside of the standard __init__.
+        Runs after command-line arguments are parsed, but before decoders are run.
+        For example, printing header data to the outfile.
+        """
+        pass
+
 
 class FileOutput(Output):
 


### PR DESCRIPTION
This pull request attempts to solve the issue highlighted in pull request #82 

It creates a 'setup' function that output modules can use to perform actions after command-line arguments are read, but before decoders do all of their input processing.

For example, this will allow the colorout module to print its HTML header data to a user-defined file before the followstream decoder prints any of its output. It also avoids the need to clear out any arguments provided to an output module's `__init__` function in the decoder.