### PR TITLE
Close Output Module in Followstream

### DIFF
--- a/decoders/misc/followstream.py
+++ b/decoders/misc/followstream.py
@@ -70,6 +70,9 @@ Example:
         # overwrite the output module's default error handler
         self.out.errorH = self.__errorHandler
 
+    def postModule(self):
+        self.out.close()
+
     def connectionHandler(self, connection):
 
         try:


### PR DESCRIPTION
I recently noted that the closing body and html tags were not being applied in HTML output from followstream.  Looking into it further, I noted that when output modules are instantiated from within the decoder's `__init__`, they are not closed by decode.py because `out` now differs from `decoder.out` within decode's `main`.

I explored calling `self.out.close()` from the decoder's `__del__`, but by the time this function is called (at the end of decode.py's main) the filehandle (`decoder.out.fh` = `out.fh`) has been closed, so colorout's attempt to write the closing tags generates a ValueError (I/O operation on closed file).

Another approach would be to test each decoder at the end of `main` to see if its output decoder is equal to the default out and close it appropriately, but I didn't want to make this change unilaterally.