### PR TITLE
Custom ErrorH for Followstream

### DIFF
--- a/decoders/misc/followstream.py
+++ b/decoders/misc/followstream.py
@@ -52,7 +52,8 @@ Example:
     def __errorHandler(self, blob, expected, offset, caller):
         # Custom error handler that is called when data in a blob is missing or
         # overlapping
-        if offset > expected:  # data is missing
+        if offset > expected and expected != 0:  # data is missing
+        	  # Do not report when expected sequence is zero as this is possible but unlikely
             self.data_missing_message += "[%d missing bytes]" % (
                 offset - expected)
         elif offset < expected:  # data is overlapping


### PR DESCRIPTION
Custom error handler changed to _not_ report missing bytes when expected sequence number is 0.  This condition occurs when using the `--followstream_ignore_handshake` flag even though no bytes were dropped.

Yes, there is an outside chance that the real expected sequence would be 0, but it seems like a low enough chance to implement this way.  Thoughts?