### PR TITLE
Fix for Multiple Packets During Blob Reconstruction

### DIFF
--- a/lib/dshell.py
+++ b/lib/dshell.py
@@ -1050,7 +1050,7 @@ class Blob(Data):
         '''returns segments of blob as string'''
         return self.data(padding='')
 
-    def data(self, errorHandler=None, padding=None, overlap=True, caller=None, dup=-1):
+    def data(self, errorHandler=None, padding=None, overlap=True, caller=None):
         '''returns segments of blob reassembled into a string
            if next segment offset is not the expected offset
            errorHandler(blob,expected,offset) will be called
@@ -1067,6 +1067,7 @@ class Blob(Data):
             dup: how to handle duplicate segments:
                 0: use first segment seen
                 -1 (default): use last segment seen
+            changing duplicate segment handling to always take largest segment
         '''
         d = ''
         nextoffset = self.startoffset
@@ -1086,12 +1087,17 @@ class Blob(Data):
                         raise KeyError(nextoffset)
                 elif segoffset < nextoffset and not overlap:
                     continue  # skip if not allowing overlap
+            #find most data in segments
+            seg = ''
+            for x in self.segments[segoffset]:
+                if len(x) > len(seg):
+                    seg = x
             # advance next expected offset
             nextoffset = (
-                segoffset + len(self.segments[segoffset][dup])) & self.MAX_OFFSET
+                segoffset + len(seg)) & self.MAX_OFFSET
             # append or splice data
             d = d[:segoffset - self.startoffset] + \
-                self.segments[segoffset][dup] + \
+                seg + \
                 d[nextoffset - self.startoffset:]
         return d
 


### PR DESCRIPTION
Fixes blob reconstruction in cases where multiple packets of different sizes were sent.  This takes the approach that we should always take the largest data packet since they should all contain the same data.