### PR TITLE
Output Mode Fix

### DIFF
--- a/decoders/http/httpdump.py
+++ b/decoders/http/httpdump.py
@@ -3,6 +3,7 @@ import util
 import hashlib
 import urllib
 import re
+import colorout
 
 from httpdecoder import HTTPDecoder
 
@@ -25,7 +26,7 @@ class DshellDecoder(HTTPDecoder):
                                  'urlfilter': {'type': 'string', 'default': None, 'help': 'Filter to URLs matching this regex'},
                              },
                              )
-        self.output = 'colorout'
+        self.out = colorout.ColorOutput()
         # Disable auto-gunzip as we want to indicate content that was
         # compressed in the output
         self.gunzip = False

--- a/decoders/smb/psexec.py
+++ b/decoders/smb/psexec.py
@@ -52,7 +52,7 @@ class DshellDecoder(SMBDecoder):
                            )
         self.legacy = True
         # self.out=colorout.ColorOutput(title='psexec')
-        self.output = 'colorout'
+        self.out = colorout.ColorOutput()
 
     def sessIndexFromPID(self, conn, pid):
         return ':'.join((str(conn.starttime), conn.sip, str(conn.sport), conn.dip, str(conn.dport), pid))


### PR DESCRIPTION
These decoders were specifying their output preference using the deprecated method of setting `self.output` to the string/name of the output library.  This pull updates them to set `self.out = colorout.ColorOutput()` in the decoders' initialization member.
