### PR TITLE
Error with created Connection for chained decoders

### DIFF
--- a/decoders/misc/xor.py
+++ b/decoders/misc/xor.py
@@ -50,6 +50,7 @@ class DshellDecoder(dshell.TCPDecoder):
     def connectionInitHandler(self, conn):
         # need to set up a custom connection tracker to handle
         self.xorconn[conn.addr] = dshell.Connection(self, conn.addr, conn.ts)
+        self.xorconn[conn.addr].nextoffset = conn.nextoffset
         # self.xorconn[conn.addr]=conn
 
     #

--- a/decoders/misc/xor.py
+++ b/decoders/misc/xor.py
@@ -51,7 +51,8 @@ class DshellDecoder(dshell.TCPDecoder):
         # need to set up a custom connection tracker to handle
         self.xorconn[conn.addr] = dshell.Connection(self, conn.addr, conn.ts)
         self.xorconn[conn.addr].nextoffset = conn.nextoffset
-        # self.xorconn[conn.addr]=conn
+        self.xorconn[conn.addr].proto = conn.proto
+        self.xorconn[conn.addr].info(proto=conn.proto)
 
     #
     # Each blob will be xor'ed and the "newblob" data will be added to the connection


### PR DESCRIPTION
Pull #99 created a case where, if a decoder (such as xor) internally creates a Connection (e.g. for use with downstream chained decoders), the new object's `nextoffset` member references NoneType values instead of integers.  And within the context of normal chained decoder operation, there is no condition wherein IPHandler would be called with a SYN flag to establish the natural starting offsets.

Prior to #99, the default values were 0, so the internal object would function, albeit with artificial sequence numbers.

My proposed solution is to manually (in the decoder) set the starting values of nextoffset to match the values of the "parent" Connection.

_Note:  This condition doesn't impact other chainable decoders (such as country filters or grep) because those decoders don't create a new Connection object.  They simply select which connections to pass downstream vs not._

For reference, the following error was observed running xor+followstream, leading to the identification of this bug:
```
ARNING:xor:unsupported operand type(s) for +: 'NoneType' and 'int'
WARNING:xor:unsupported operand type(s) for +: 'NoneType' and 'int'
WARNING:xor:unsupported operand type(s) for +: 'NoneType' and 'int'
```