### PR TITLE
Web decoder overhaul

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -259,6 +259,8 @@ def getopts(args, options,
 
 
 def getHeader(request_or_response, header_name):
+    if request_or_response == None:
+        return ''
     try:
         httpHdr = request_or_response.headers[header_name]
     except:
@@ -269,7 +271,10 @@ def getHeader(request_or_response, header_name):
         # return unique list joined by ','
         return ', '.join(set(httpHdr))
     else:
-        return ''
+        try:
+          return unicode(httpHdr).encode('utf-8')
+        except:
+          return ''
 
 # HTTPlastmodified - Extracts last-modified (or date) header from
 #                    HTTP response headers and normalizes date string format


### PR DESCRIPTION
I've been meaning to look at this for a while.  General use of the web decoder has been throwing UnicodeEncodeError on certain types of traffic.  The cause seemed to be in the line `if response:` (line 88 currently), which is just checking to see if we have a response object available.  _(Sometimes the response isn't captured and we obviously want Dshell to handle those conditions gracefully.)_ The existing expression seems to cause an invocation of len() on the `dpkt.http.Message` object (when it exists), which causes the UnicodeEncodeError exception on evaluating `len(str(self))`.

The problem is probably in dpkt, but rather than dig into that, I changed our statement such that it checks for a response by comparison with None: `if response!=None:`.  This accomplishes the decoder's purpose and is probably slightly more efficient as well.

While working on the module, I did some other code cleanup and reworked the keyword-value motif so that **all** HTTP headers (client and server) are now passed as keys to `alert()`.  I am a big user of jsonout, so this has proven very useful in my analysis.

_Side note: I thought tweaking the key-names so that request and response headers were more distinguished, but weighed this against the backward compatibility advantage of keeping key names consistent with the current decoder._