### PR TITLE
Check for postParams with single null value

### DIFF
--- a/decoders/http/httpdump.py
+++ b/decoders/http/httpdump.py
@@ -76,6 +76,9 @@ class DshellDecoder(HTTPDecoder):
                 request.method, response.status, host, uri_location, util.getHeader(response, 'content-type'))
         urlParams = util.URLDataToParameterDict(uri_data)
         postParams = util.URLDataToParameterDict(request.body)
+        # If URLData parser only returns a single element with null value, it's probably an eroneous evaluation.  Most likely base64 encoded payload ending in an '=' character.
+        if len(postParams)==1 and postParams[postParams.keys()[0]] == '\x00':
+        	postParams = None
 
         clientCookies = self._parseCookies(util.getHeader(request, 'cookie'))
         serverCookies = self._parseCookies(


### PR DESCRIPTION
I noticed a fairly common condition where base64 text was passed as HTTP post data, wherein the utility function `URLDataToParameterDict` would return a single element dictionary with a null value.  This seems to occur when the base64 text is a null terminated string ending in a `=` character:
```
>>> postParams = util.URLDataToParameterDict('A=\0')
>>> postParams
{'A': '\x00'}
```
This was causing errors in the display of POST parameters and generally not useful in context of this decoder.
