### PR TITLE
Removing print statement, appears to be leftover from debugging module

### DIFF
--- a/dshell/plugins/http/web.py
+++ b/dshell/plugins/http/web.py
@@ -58,8 +58,10 @@ class DshellPlugin(HTTPPlugin):
                                                  hash)
         if not request:
             self.write(data, method=method, host=host, uri=uri, version=version, status=status, reason=reason, hash=hash, **response.blob.info())
-        else:
+        elif not response:
             self.write(data, method=method, uri=uri, version=version, status=status, reason=reason, hash=hash, **request.headers, **request.blob.info())
+        else:
+        	self.write(data, method=method, uri=uri, version=version, status=status, reason=reason, hash=hash, response_headers=response.headers, **request.headers, **request.blob.info())
         return conn, request, response
 
 if __name__ == "__main__":

--- a/dshell/plugins/http/web.py
+++ b/dshell/plugins/http/web.py
@@ -61,7 +61,7 @@ class DshellPlugin(HTTPPlugin):
         elif not response:
             self.write(data, method=method, uri=uri, version=version, status=status, reason=reason, hash=hash, **request.headers, **request.blob.info())
         else:
-        	self.write(data, method=method, uri=uri, version=version, status=status, reason=reason, hash=hash, response_headers=response.headers, **request.headers, **request.blob.info())
+        	self.write(data, method=method, uri=uri, version=version, status=status, reason=reason, hash=hash, request_headers=request.headers, response_headers=response.headers, **request.blob.info())
         return conn, request, response
 
 if __name__ == "__main__":

--- a/dshell/plugins/http/web.py
+++ b/dshell/plugins/http/web.py
@@ -26,7 +26,6 @@ class DshellPlugin(HTTPPlugin):
             # Collect basics about the request, if available
             method = request.method
             host = request.headers.get("host", "")
-            print(request.headers)
             uri = request.uri
 #            useragent = request.headers.get("user-agent", None)
 #            referer = request.headers.get("referer", None)


### PR DESCRIPTION
This PR requests rolls up two commits:
1) Print statement resulted in header dictionary being written to stdout, outside of output module control.
2) I've found it useful to have more verbose request *and* response headers in the JSON output.  To avoid name-space conflicts, I like to have these as nested objects in the dictionary.  In this PR I'm only adding the response headers as `response_headers`, whereas the request headers are already merged into the outer kwarg dictionary.... I could easily see rolling these up similarly under a `request_headers` label.