### PR TITLE
Handle plugin specified diverse directions for non connection/blob objects in colorized/html output

### DIFF
--- a/dshell/output/colorout.py
+++ b/dshell/output/colorout.py
@@ -64,6 +64,8 @@ End:   %(endtime)s
                         rawdata.append((blob.data, blob.direction))
             elif type(arg) == dshell.core.Packet:
                 rawdata.append((arg.pkt.body_bytes, kwargs.get('direction', '--')))
+            elif type(arg) == tuple:
+                rawdata.append(arg)
             else:
                 rawdata.append((arg, kwargs.get('direction', '--')))
 

--- a/dshell/output/htmlout.py
+++ b/dshell/output/htmlout.py
@@ -98,6 +98,8 @@ End: %(endtime)s
                         rawdata.append((blob.data, blob.direction))
             elif type(arg) == dshell.core.Packet:
                 rawdata.append((arg.pkt.body_bytes, kwargs.get('direction', '--')))
+            elif type(arg) == tuple:
+                rawdata.append(arg)
             else:
                 rawdata.append((arg, kwargs.get('direction', '--')))
 


### PR DESCRIPTION
In the previous version of colorout, decoders would make multiple calls to write(), specifying direction on each call. This allowed for output that indicated the directionality of back-and-forth communications. Version three changes the behavior slightly, having the output module format a connection/packet header and then iterate through multiple related elements.  This works fine for blobs which have their directionality specified internally, but there is currently no mechanism for the decoder plugin to specify the direction.

This is just one potential approach to a solution. I'm quite open to discussion.  But because the output module already passes tuples of (data, direction) internally this seemed to make sense.