### PR TITLE
Override line-break delimiter for followstream module

### DIFF
--- a/dshell/plugins/misc/followstream.py
+++ b/dshell/plugins/misc/followstream.py
@@ -16,6 +16,10 @@ class DshellPlugin(dshell.core.ConnectionPlugin):
             output=ColorOutput(label=__name__),
         )
 
+    def premodule(self):
+        if 'delim' in dir(self.out):
+            self.out.delim = ''
+
     def connection_handler(self, conn):
         if (conn.clientbytes + conn.serverbytes > 0):
             self.write(conn, **conn.info())


### PR DESCRIPTION
This may just be personal preference, but the line-break added to the end of each blob in followstream output makes typical flows more difficult to read (for me). Without the line-break, the output more closely approximates that of Wireshark's follow stream output.