### PR TITLE
Add sanity checks to web decoder

### DIFF
--- a/dshell/plugins/http/web.py
+++ b/dshell/plugins/http/web.py
@@ -27,7 +27,7 @@ class DshellPlugin(HTTPPlugin):
             if request.method=="":
                 # It's impossible to have a properly formed HTTP request without a method
                 # indicating, the httpplugin is calling http_handler without a full object
-                return conn, request, response
+                return None
             # Collect basics about the request, if available
             method = request.method
             host = request.headers.get("host", "")
@@ -44,7 +44,7 @@ class DshellPlugin(HTTPPlugin):
         if response:
             if response.status == "" and response.reason == "":
                 # Another indication of improperly parsed HTTP object in httpplugin
-                return conn, request, response
+                return None
             # Collect basics about the response, if available
             status = response.status
             reason = response.reason

--- a/dshell/plugins/http/web.py
+++ b/dshell/plugins/http/web.py
@@ -22,7 +22,12 @@ class DshellPlugin(HTTPPlugin):
         )
 
     def http_handler(self, conn, request, response):
+     
         if request:
+            if request.method=="":
+                # It's impossible to have a properly formed HTTP request without a method
+                # indicating, the httpplugin is calling http_handler without a full object
+                return conn, request, response
             # Collect basics about the request, if available
             method = request.method
             host = request.headers.get("host", "")
@@ -37,6 +42,9 @@ class DshellPlugin(HTTPPlugin):
             version = ""
 
         if response:
+            if response.status == "" and response.reason == "":
+                # Another indication of improperly parsed HTTP object in httpplugin
+                return conn, request, response
             # Collect basics about the response, if available
             status = response.status
             reason = response.reason


### PR DESCRIPTION
This commit adds two checks on the request/response objects passed to http_handler, trying to determine if those objects are completely and/or actually HTTP objects.