### PR TITLE
Cleaning up Json Output

### DIFF
--- a/dshell/output/jsonout.py
+++ b/dshell/output/jsonout.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import json
 from dshell.output.output import Output
 
-
 class JSONOutput(Output):
     """
     Converts arguments for every write into JSON
@@ -26,6 +25,11 @@ class JSONOutput(Output):
             self.extra = False
         if args and 'data' not in kwargs:
             kwargs['data'] = self.delim.join(map(str, args))
+        if 'packets' in kwargs:
+            del kwargs['packets']
+        for k in list(kwargs.keys()):
+            if k.startswith('_'):
+              del kwargs[k]
         jsondata = json.dumps(kwargs, ensure_ascii=self.ensure_ascii, default=self.json_default)
         super().write(jsondata=jsondata)
 


### PR DESCRIPTION
Recent changes in the core code have resulted in additional data being presented to the jsonout module (by way, I gather of data fed from `blob.info()` and/or `conn.info()`.  Namely these are _internal_ data members starting with an underscore character and a complete list of packets related to the connection or blob.  Not only do these items clutter json output, but largely they are throwing "Type not serializable" errors as they are not `datetime` or `bytes` objects.

I'm completely open to other approaches here, such as providing serialization methods for more data types in the jsonout module, but the completely list of Packets seemed of limited use in json output, at least for my needs.