### PR TITLE
Optimizations

### DIFF
--- a/dshell/core.py
+++ b/dshell/core.py
@@ -493,7 +493,7 @@ class ConnectionPlugin(PacketPlugin):
         # the timestamp of the connection's last packet is older than the
         # timestamp of the current packet, minus this value
         self.timeout = datetime.timedelta(hours=1)
-        # The frequency of packets to process between timeout checks.
+        # The number of packets to process between timeout checks.
         self.timeout_frequency = 300
         # The maximum number of open connections allowed at one time.
         # If the maximum number of connections is met, the oldest connections
@@ -872,7 +872,7 @@ class Packet(object):
         ip_p = None
         tcp_p = None
         udp_p = None
-        highest_layer = packet
+        highest_layer = None
         for layer in packet:
             highest_layer = layer
             if ethernet_p is None and isinstance(layer, ethernet.Ethernet):
@@ -1050,7 +1050,7 @@ class Packet(object):
         Provides a dictionary with information about a packet. Useful for
         calls to a plugin's write() function, e.g. self.write(\\*\\*pkt.info())
         """
-        d = {k: v for k, v in self.__dict__ if not k.startswith('_')}
+        d = {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
         d['byte_count'] = self.byte_count
         del d['pkt']
         return d
@@ -1272,7 +1272,7 @@ class Connection(object):
         Returns:
             Dictionary with information
         """
-        d = {k: v for k, v in self.__dict__ if not k.startswith('_')}
+        d = {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
         d['duration'] = self.duration
         d['clientbytes'] = self.clientbytes
         d['clientpackets'] = self.clientpackets
@@ -1787,9 +1787,8 @@ class Blob(object):
         Returns:
             Dictionary with information
         """
-        d = dict(self.__dict__)
+        d = {k: v for k, v in self.__dict__.items() if not k.startswith('_')}
         del d['hidden']
-        del d['_Blob__data_bytes']
         del d['packets']
         return d
 

--- a/dshell/decode.py
+++ b/dshell/decode.py
@@ -79,6 +79,13 @@ def feed_plugin_chain(plugin_index: int, packet: Packet):
     if next_plugin_index:
         for _packet in current_plugin.produce_packets():
             feed_plugin_chain(next_plugin_index, _packet)
+    else:
+        # For the last plugin in the chain we still need to call produce_packets()
+        # to release resources for already processed packets.
+        # This prevents us consuming too much memory or processing time for large pcaps
+        # or long running live captures.
+        for _ in current_plugin.produce_packets():
+            pass
 
 
 def clean_plugin_chain(plugin_index):

--- a/dshell/decode.py
+++ b/dshell/decode.py
@@ -106,6 +106,13 @@ def clean_plugin_chain(plugin_index):
         for _packet in current_plugin.produce_packets():
             feed_plugin_chain(next_plugin_index, _packet)
         clean_plugin_chain(next_plugin_index)
+    else:
+        # For the last plugin in the chain we still need to call produce_packets()
+        # to release resources for already processed packets.
+        # This prevents us consuming too much memory or processing time for large pcaps
+        # or long running live captures.
+        for _ in current_plugin.produce_packets():
+            pass
 
 
 def decompress_file(filepath, extension, unzipdir):

--- a/dshell/decode.py
+++ b/dshell/decode.py
@@ -510,11 +510,7 @@ def process_files(inputs, **kwargs):
 
         clean_plugin_chain(0)
         for plugin in plugin_chain:
-            try:
-                plugin._purge_connections()
-            except AttributeError:
-                # probably just a packet plugin
-                pass
+            plugin.purge()
             plugin._postfile()
 
 

--- a/dshell/decode.py
+++ b/dshell/decode.py
@@ -65,27 +65,18 @@ def feed_plugin_chain(plugin_index: int, packet: Packet):
     Each plugin decides whether the packet(s) will proceed to the next
     plugin, i.e. act as a filter.
     """
-    global plugin_chain
+    if plugin_index >= len(plugin_chain):
+        # We are at the end of the chain.
+        return
 
     current_plugin = plugin_chain[plugin_index]
-    next_plugin_index = plugin_index + 1
-    if next_plugin_index >= len(plugin_chain):
-        next_plugin_index = None
 
     # Pass packet into plugin for processing.
     current_plugin.consume_packet(packet)
 
     # Process produced packets.
-    if next_plugin_index:
-        for _packet in current_plugin.produce_packets():
-            feed_plugin_chain(next_plugin_index, _packet)
-    else:
-        # For the last plugin in the chain we still need to call produce_packets()
-        # to release resources for already processed packets.
-        # This prevents us consuming too much memory or processing time for large pcaps
-        # or long running live captures.
-        for _ in current_plugin.produce_packets():
-            pass
+    for _packet in current_plugin.produce_packets():
+        feed_plugin_chain(plugin_index + 1, _packet)
 
 
 def clean_plugin_chain(plugin_index):
@@ -94,25 +85,20 @@ def clean_plugin_chain(plugin_index):
     It will go through the plugins and attempt to cleanup any connections
     that were not yet closed.
     """
+    if plugin_index >= len(plugin_chain):
+        # We are at the end of the chain
+        return
+
     current_plugin = plugin_chain[plugin_index]
-    next_plugin_index = plugin_index + 1
-    if next_plugin_index >= len(plugin_chain):
-        next_plugin_index = None
 
     # need to flush even if there are no more plugins in the chain to ensure all packets are processed.
     current_plugin.flush()
 
-    if next_plugin_index:
-        for _packet in current_plugin.produce_packets():
-            feed_plugin_chain(next_plugin_index, _packet)
-        clean_plugin_chain(next_plugin_index)
-    else:
-        # For the last plugin in the chain we still need to call produce_packets()
-        # to release resources for already processed packets.
-        # This prevents us consuming too much memory or processing time for large pcaps
-        # or long running live captures.
-        for _ in current_plugin.produce_packets():
-            pass
+    # Feed plugin chain with lingering packets released by flush.
+    for _packet in current_plugin.produce_packets():
+        feed_plugin_chain(plugin_index + 1, _packet)
+
+    clean_plugin_chain(plugin_index + 1)
 
 
 def decompress_file(filepath, extension, unzipdir):


### PR DESCRIPTION
This merge request contains some optimizations to help improve processing speed.

This was made after the discovery that if dshell can't determine when a connection is closed, it will hold onto the connection in the `_connection_tracker`. This was causing the `_connection_handler()` to slow down proportionally to the number of lingering open connections. 

This caused a 244 MB pcap to take multiple hours to complete. After these changes, processing only took 20 minutes.

- Added a limiter to timeout connections if a maximum of 1000 (arbitrarily determined) connections is hit. (This goes along with the 1 hour timeout already implemented.) 
- Set the check for timing out connections to happen after every 300 packets instead of being run with each packet.
- Set `produce_packets()` to be run even on the last plugin in the chains. This is to ensure resources are periodically cleaned up and we don't miss handling a lingering connection.
- Moved connection handling to occur during `produce_connections()` and set `_connection_queue` to be a priority queue to help ensure connections are processed in order relative to packet capture.