### PR TITLE
Fixes for JSON output

### DIFF
--- a/dshell/core.py
+++ b/dshell/core.py
@@ -1280,6 +1280,7 @@ class Connection(object):
         d['serverpackets'] = self.serverpackets
         del d['stop']
         del d['handled']
+        del d['packets']
         return d
 
     def _client_packets(self) -> Iterable[Packet]:

--- a/dshell/output/jsonout.py
+++ b/dshell/output/jsonout.py
@@ -5,7 +5,7 @@ This output module converts plugin output into JSON
 from datetime import datetime
 import json
 from dshell.output.output import Output
-
+from dshell.core import Packet, Blob, Connection
 
 class JSONOutput(Output):
     """
@@ -39,6 +39,9 @@ class JSONOutput(Output):
             return serial
         if isinstance(obj, bytes):
             serial = repr(obj)
+            return serial
+        if isinstance(obj, (Connection, Blob, Packet)):
+            serial = obj.info()
             return serial
         raise TypeError ("Type not serializable ({})".format(str(type(obj))))
 


### PR DESCRIPTION
Fixes for JSON output. Prevented .info() calls from returning a full list of packets, and making some core Dshell classes serializable.

This is an alternative fix to #136 