### PR TITLE
Altered --oarg flag to work with all output modules

### DIFF
--- a/dshell/output/csvout.py
+++ b/dshell/output/csvout.py
@@ -10,7 +10,7 @@ class CSVOutput(Output):
     Takes specified fields provided to the write function and print them in
     a CSV format.
 
-    Delimiter can be set with --oarg delim=<char>
+    Delimiter can be set with --oarg delimiter=<char>
 
     A header row can be printed with --oarg header
 
@@ -26,7 +26,7 @@ class CSVOutput(Output):
     _DESCRIPTION = "CSV format output"
 
     def __init__(self, *args, **kwargs):
-        self.delimiter = kwargs.get('delim', self._DEFAULT_DELIM)
+        self.delimiter = kwargs.get('delimiter', self._DEFAULT_DELIM)
         if self.delimiter == 'tab':
             self.delimiter = '\t'
 
@@ -52,6 +52,10 @@ class CSVOutput(Output):
         fmt = self.delimiter.join('%%(%s)r' % f for f in columns)
         fmt += "\n"
         super().set_format(fmt)
+
+    def set_oargs(self, **kwargs):
+        super().set_oargs(**kwargs)
+        self.set_format()
 
     def setup(self):
         if self.use_header:

--- a/dshell/output/elasticout.py
+++ b/dshell/output/elasticout.py
@@ -43,7 +43,7 @@ class ElasticOutput(dshell.output.jsonout.JSONOutput):
     def write(self, *args, **kwargs):
         "Converts alert's keyword args to JSON and indexes it into Elasticsearch datastore."
         if args and 'data' not in kwargs:
-            kwargs['data'] = self.delim.join(map(str, args))
+            kwargs['data'] = self.delimiter.join(map(str, args))
 
         # Elasticsearch can't handle IPv6 (at time of writing)
         # Just delete the ints and expand the string notation.


### PR DESCRIPTION
Altered --oarg flag to work with all output modules, including plugin defaults. Previously, --oarg could only be used with --omodule. This change should allow users to alter certain parts of regular output, and partially solve #131.

Also changed instances of 'delim' to 'delimiter' in the code, to clarify meaning.