### PR TITLE
Add handler for hexout in set_oargs

### DIFF
--- a/dshell/output/output.py
+++ b/dshell/output/output.py
@@ -82,7 +82,7 @@ class Output:
             else:
                 self.fh = open(filename, self.mode)
 
-    def set_oargs(self, format=None, noclobber=None, delimiter=None, timeformat=None, **unused_kwargs):
+    def set_oargs(self, format=None, noclobber=None, delimiter=None, timeformat=None, hex=None, **unused_kwargs):
         """
         Process the standard oargs from the command line.
         """
@@ -92,6 +92,8 @@ class Output:
             self.timeformat = timeformat
         if noclobber:
             self.noclobber = noclobber
+        if hex:
+            self.hexmode = hex
         if format:
             self.set_format(format)
 


### PR DESCRIPTION
Recent changes in oargs caused followstream (and probably other module) hexout when invoked with `--oarg hex` to no longer work. This should correct the issue, but we probably need a more robust mechanism for generically setting output args from decode.py.