### PR TITLE
Color blind friendly mode patch

### DIFF
--- a/dshell/decode.py
+++ b/dshell/decode.py
@@ -538,7 +538,7 @@ def main_command_line():
                       help="Show debug messages")
     parser.add_argument('-v', '--verbose', action="store_true",
                       help="Show informational messages")
-    parser.add_argument('-acc', '--allcc', action="store_true",
+    parser.add_argument('--acc', '--allcc', action="store_true",
                       help="Show all 3 GeoIP2 country code types (represented_country/registered_country/country)")
     parser.add_argument('-d', '-p', '--plugin', dest='plugin', type=str,
                       action='append', metavar="PLUGIN",
@@ -580,7 +580,7 @@ def main_command_line():
     output_group.add_argument("--no-buffer", action="store_true",
                             help="Do not buffer plugin output",
                             dest="nobuffer")
-    output_group.add_argument("-cbf", "--color-blind-friendly", action="store_true",
+    output_group.add_argument("--cbf", "--color-blind-friendly", action="store_true",
                             help="Activate color blind friendly mode, colorout and htmlout output modules use yellow/gold in place of red and different shades of green/yellow/blue are used to help better differentiate between them",
                             dest="cbf")    
     output_group.add_argument("-x", "--extra", action="store_true",
@@ -623,7 +623,7 @@ def main_command_line():
                       help='List all available plugins', dest='list')
     parser_short.add_argument("--lo", "--list-output", action="store_true",
                             help="List available output modules")
-    parser_short.add_argument("-cbf", "--color-blind-friendly", action="store_true",
+    parser_short.add_argument("--cbf", "--color-blind-friendly", action="store_true",
                             help="Activate color blind friendly mode, colorout and htmlout output modules use yellow/gold in place of red and different shades of green/yellow/blue are used to help better differentiate between them")   
     # FIXME: Should this duplicate option be removed?
     parser_short.add_argument("-o", "--omodule", type=str, metavar="MODULE",

--- a/dshell/decode.py
+++ b/dshell/decode.py
@@ -232,26 +232,27 @@ def main(plugin_args=None, **kwargs):
         for plugin in plugin_chain:
             plugin.out.set_oargs(**oargs)
 
-    # If writing to a file, set for each output module here
-    if kwargs.get("outfile", None):
-        for plugin in plugin_chain:
+    for plugin in plugin_chain:
+        # If writing to a file, set for each output module here
+        if kwargs.get("outfile", None):
             plugin.out.reset_fh(filename=kwargs["outfile"])
 
-    # Set nobuffer mode if that's what the user wants
-    if kwargs.get("nobuffer", False):
-        for plugin in plugin_chain:
+        # Set nobuffer mode if that's what the user wants
+        if kwargs.get("nobuffer", False):
             plugin.out.nobuffer = True
+            
+        # Set color blind friendly mode
+        if kwargs.get("cbf", False):
+            plugin.out.cbf = True
 
-    # Set the extra flag for all output modules
-    if kwargs.get("extra", False):
-        for plugin in plugin_chain:
+        # Set the extra flag for all output modules
+        if kwargs.get("extra", False):
             plugin.out.extra = True
             plugin.out.set_format(plugin.out.format)
 
-    # Set the BPF filters
-    # Each plugin has its own default BPF that will be extended or replaced
-    # based on --no-vlan, --ebpf, or --bpf arguments.
-    for plugin in plugin_chain:
+        # Set the BPF filters
+        # Each plugin has its own default BPF that will be extended or replaced
+        # based on --no-vlan, --ebpf, or --bpf arguments.
         if kwargs.get("bpf", None):
             plugin.bpf = kwargs.get("bpf", "")
             continue
@@ -579,6 +580,9 @@ def main_command_line():
     output_group.add_argument("--no-buffer", action="store_true",
                             help="Do not buffer plugin output",
                             dest="nobuffer")
+    output_group.add_argument("-cbf", "--color-blind-friendly", action="store_true",
+                            help="Activate color blind friendly mode, colorout and htmlout output modules use yellow/gold in place of red and different shades of green/yellow/blue are used to help better differentiate between them",
+                            dest="cbf")    
     output_group.add_argument("-x", "--extra", action="store_true",
                             help="Appends extra data to all plugin output.")
     # TODO Figure out how to make --extra flag play nicely with user-only
@@ -619,6 +623,8 @@ def main_command_line():
                       help='List all available plugins', dest='list')
     parser_short.add_argument("--lo", "--list-output", action="store_true",
                             help="List available output modules")
+    parser_short.add_argument("-cbf", "--color-blind-friendly", action="store_true",
+                            help="Activate color blind friendly mode, colorout and htmlout output modules use yellow/gold in place of red and different shades of green/yellow/blue are used to help better differentiate between them")   
     # FIXME: Should this duplicate option be removed?
     parser_short.add_argument("-o", "--omodule", type=str, metavar="MODULE",
                             help="Use specified output module for plugins instead of defaults. For example, --omodule=jsonout for JSON output.")

--- a/dshell/output/colorout.py
+++ b/dshell/output/colorout.py
@@ -37,7 +37,7 @@ End:   %(endtime)s
             'cs': '31',   # client-to-server is red
             'sc': '32',   # server-to-client is green
             '--': '34',   # everything else is blue
-        }  # TODO configurable for color-blind users?
+        }
         self.hexmode = kwargs.get('hex', False)
         self.format_is_set = False
 

--- a/dshell/output/colorout.py
+++ b/dshell/output/colorout.py
@@ -41,6 +41,11 @@ End:   %(endtime)s
         self.hexmode = kwargs.get('hex', False)
         self.format_is_set = False
 
+    def setup(self):
+        # activate color blind friendly mode
+        if self.cbf:
+            self.colors['cs'] = '33'   #client-to-server is yellow
+    
     def write(self, *args, **kwargs):
         if not self.format_is_set:
             if 'clientip' in kwargs:

--- a/dshell/output/htmlout.py
+++ b/dshell/output/htmlout.py
@@ -73,6 +73,10 @@ End: %(endtime)s
         self.format_is_set = False
 
     def setup(self):
+        # activate color blind friendly mode
+        if self.cbf:
+            self.colors['cs'] = 'gold'   # client-to-server is gold (darker yellow)
+            self.colors['sc'] = 'seagreen'   # server-to-client is sea green (lighter green)
         self.fh.write(self._HTML_HEADER)
 
     def write(self, *args, **kwargs):

--- a/dshell/output/output.py
+++ b/dshell/output/output.py
@@ -29,6 +29,9 @@ class Output:
         fh : existing open file handle
         file : filename to write to, assuming fh is not defined
         mode : mode to open file, assuming fh is not defined (default 'w')
+        cbf : activate color blind friendly mode, colorout and htmlout output
+              modules use yellow/gold in place of red and different shades of
+              green/yellow/blue are used to help better differentiate between them
     """
     _DEFAULT_FORMAT = "%(data)s\n"
     _DEFAULT_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -37,7 +40,7 @@ class Output:
 
     def __init__(
             self, file=None, fh=None, mode='w', format=None, timeformat=None, delimiter=None, nobuffer=False,
-            noclobber=False, extra=None, **unused_kwargs
+            noclobber=False, extra=None, cbf=False, **unused_kwargs
     ):
         self.format_fields = []
         self.timeformat = timeformat or self._DEFAULT_TIME_FORMAT
@@ -46,6 +49,7 @@ class Output:
         self.noclobber = noclobber
         self.extra = extra
         self.mode = mode
+        self.cbf = cbf
 
         # Must define attributes even if they are setup in different function.
         self.format_fields = None


### PR DESCRIPTION
Added color blind friendly mode, which will currently be used by the colorout and htmlout output modules.  Uses yellow/gold in place of red and different shades of green/yellow/blue to help users with protanopia, deuteranopia, or tritanopia better differentiate between them, as well as for users interested in alternate color schemes.